### PR TITLE
Run .bat/.cmd engines through cmd.exe on Windows

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -2,6 +2,7 @@ const EventEmitter = require('events')
 const {spawn, exec} = require('./ponyfills/child_process')
 const {StreamController} = require('./main')
 const {lineSubscribe} = require('./helper')
+const {prepareSpawn} = require('./spawn')
 
 class Controller extends EventEmitter {
   constructor(path, args = [], spawnOptions = {}) {
@@ -26,7 +27,12 @@ class Controller extends EventEmitter {
   start() {
     if (this.process != null) return
 
-    this.process = spawn(this.path, this.args, this.spawnOptions)
+    let {command, args, options} = prepareSpawn(
+      this.path,
+      this.args,
+      this.spawnOptions
+    )
+    this.process = spawn(command, args, options)
 
     this._unsubscribeStderr = lineSubscribe(this.process.stderr, line => {
       this.emit('stderr', {content: line})

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 exports.Command = require('./Command')
 exports.Response = require('./Response')
+exports.prepareSpawn = require('./spawn').prepareSpawn
 
 exports.StreamController = require('./StreamController')
 exports.Controller = require('./Controller')

--- a/src/spawn.js
+++ b/src/spawn.js
@@ -1,0 +1,94 @@
+const path = require('path')
+
+// Since Node.js 18.20.2 / 20.12.2 / 21.7.2 (CVE-2024-27980), child_process.spawn
+// on Windows refuses to run a .bat/.cmd file unless it is invoked through a shell;
+// it throws EINVAL otherwise. Batch files therefore have to be launched via
+// cmd.exe. prepareSpawn() rewrites the (command, args, options) tuple for that
+// case and leaves every other case -- all non-Windows platforms, and Windows
+// .exe/extensionless commands -- completely untouched.
+//
+// The cmd.exe argument-escaping below is a faithful port of the battle-tested
+// logic in cross-spawn 7 (https://github.com/moxystudio/node-cross-spawn, MIT).
+// Keeping it inline avoids adding a runtime dependency to this otherwise
+// dependency-free package. See tests/spawn.test.js, which cross-checks it against
+// cross-spawn's own escape functions.
+
+// cmd.exe metacharacters -- see http://www.robvanderwoude.com/escapechars.php
+const metaCharsRegExp = /([()\][%!^"`<>&|;, *?])/g
+const isBatchRegExp = /\.(?:bat|cmd)$/i
+// Matches an npm cmd-shim in node_modules/.bin: those proxy through an extra
+// cmd.exe, so their metachars must be double-escaped.
+const isCmdShimRegExp = /node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$/i
+
+function escapeCommand(arg) {
+  // Escape meta chars
+  return arg.replace(metaCharsRegExp, '^$1')
+}
+
+function escapeArgument(arg, doubleEscapeMetaChars) {
+  // Convert to string
+  arg = `${arg}`
+
+  // Sequence of backslashes followed by a double quote: double up all the
+  // backslashes and escape the double quote.
+  arg = arg.replace(/(?=(\\+?)?)\1"/g, '$1$1\\"')
+
+  // Sequence of backslashes followed by the end of the string (which will
+  // become a double quote later): double up all the backslashes.
+  arg = arg.replace(/(?=(\\+?)?)\1$/, '$1$1')
+
+  // Quote the whole thing.
+  arg = `"${arg}"`
+
+  // Escape meta chars.
+  arg = arg.replace(metaCharsRegExp, '^$1')
+
+  // Double escape meta chars if necessary.
+  if (doubleEscapeMetaChars) {
+    arg = arg.replace(metaCharsRegExp, '^$1')
+  }
+
+  return arg
+}
+
+// Returns the exact {command, args, options} tuple to hand to child_process.spawn.
+// Pure and side-effect free, so the Windows path is unit-testable on any host.
+function prepareSpawn(
+  command,
+  args = [],
+  options = {},
+  platform = process.platform
+) {
+  // Every non-Windows platform spawns exactly as before.
+  if (platform !== 'win32') {
+    return {command, args, options}
+  }
+
+  // Only .bat/.cmd files are affected; .exe and extensionless commands still
+  // spawn directly, and if the caller already opted into a shell, Node handles
+  // the batch file itself -- don't double-wrap.
+  if (!isBatchRegExp.test(command) || options.shell) {
+    return {command, args, options}
+  }
+
+  // Normalize posix separators into Windows ones (foo/bar.bat -> foo\bar.bat),
+  // otherwise cmd.exe fails to find the file. Use the win32 variant explicitly
+  // so the result is correct even when this runs on a non-Windows host.
+  const normalizedCommand = path.win32.normalize(command)
+  const needsDoubleEscapeMetaChars = isCmdShimRegExp.test(normalizedCommand)
+
+  const escapedCommand = escapeCommand(normalizedCommand)
+  const escapedArgs = args.map(arg =>
+    escapeArgument(arg, needsDoubleEscapeMetaChars)
+  )
+  const shellCommand = [escapedCommand].concat(escapedArgs).join(' ')
+
+  return {
+    command: process.env.comspec || 'cmd.exe',
+    args: ['/d', '/s', '/c', `"${shellCommand}"`],
+    // Tell Node's spawn that the arguments are already escaped.
+    options: {...options, windowsVerbatimArguments: true}
+  }
+}
+
+module.exports = {prepareSpawn, escapeCommand, escapeArgument}

--- a/tests/spawn.test.js
+++ b/tests/spawn.test.js
@@ -1,0 +1,174 @@
+const t = require('tap')
+const {prepareSpawn} = require('..')
+
+const comspec = process.env.comspec || 'cmd.exe'
+
+t.test('prepareSpawn', async t => {
+  t.test('leaves non-Windows platforms untouched', async t => {
+    for (let platform of ['darwin', 'linux']) {
+      let command = '/usr/bin/katago'
+      let args = ['gtp', '-config', 'my config.cfg']
+      let options = {cwd: '/home/user'}
+      let result = prepareSpawn(command, args, options, platform)
+
+      // Byte-for-byte identical, and the very same references (no cloning).
+      t.equal(result.command, command, `${platform}: command unchanged`)
+      t.equal(result.args, args, `${platform}: args unchanged (same ref)`)
+      t.equal(
+        result.options,
+        options,
+        `${platform}: options unchanged (same ref)`
+      )
+
+      // Even a .bat path is left alone off Windows.
+      let batResult = prepareSpawn('/x/y.bat', ['a b'], options, platform)
+      t.equal(batResult.command, '/x/y.bat', `${platform}: .bat unchanged`)
+      t.same(batResult.args, ['a b'], `${platform}: .bat args unchanged`)
+      t.notOk(
+        batResult.options.windowsVerbatimArguments,
+        `${platform}: no windowsVerbatimArguments`
+      )
+    }
+  })
+
+  t.test(
+    'leaves Windows .exe and extensionless commands untouched',
+    async t => {
+      let options = {cwd: 'C:\\e'}
+
+      let exe = prepareSpawn(
+        'C:\\engines\\katago.exe',
+        ['--gtp'],
+        options,
+        'win32'
+      )
+      t.equal(exe.command, 'C:\\engines\\katago.exe')
+      t.equal(exe.args, exe.args) // same ref preserved
+      t.same(exe.args, ['--gtp'])
+      t.equal(exe.options, options)
+      t.notOk(exe.options.windowsVerbatimArguments)
+
+      let plain = prepareSpawn('katago', ['--gtp'], {}, 'win32')
+      t.equal(plain.command, 'katago')
+      t.same(plain.args, ['--gtp'])
+    }
+  )
+
+  t.test('wraps Windows .bat through cmd.exe', async t => {
+    let options = {cwd: 'C:\\e'}
+    let result = prepareSpawn(
+      'C:\\engines\\katago.bat',
+      ['--gtp'],
+      options,
+      'win32'
+    )
+
+    t.equal(result.command, comspec, 'runs via cmd.exe/comspec')
+    t.same(result.args, [
+      '/d',
+      '/s',
+      '/c',
+      '"C:\\engines\\katago.bat ^"--gtp^""'
+    ])
+    t.equal(result.options.windowsVerbatimArguments, true)
+    t.equal(result.options.cwd, 'C:\\e', 'preserves cwd')
+  })
+
+  t.test('wraps Windows .cmd through cmd.exe', async t => {
+    let result = prepareSpawn(
+      'C:\\engines\\gnugo.cmd',
+      [],
+      {cwd: 'C:\\e'},
+      'win32'
+    )
+
+    t.equal(result.command, comspec)
+    t.same(result.args, ['/d', '/s', '/c', '"C:\\engines\\gnugo.cmd"'])
+    t.equal(result.options.windowsVerbatimArguments, true)
+    t.equal(result.options.cwd, 'C:\\e')
+  })
+
+  t.test('matches the extension case-insensitively', async t => {
+    let result = prepareSpawn('C:\\engines\\Katago.BAT', [], {}, 'win32')
+
+    t.equal(result.command, comspec)
+    t.same(result.args, ['/d', '/s', '/c', '"C:\\engines\\Katago.BAT"'])
+    t.equal(result.options.windowsVerbatimArguments, true)
+  })
+
+  t.test('quotes arguments and command paths containing spaces', async t => {
+    let result = prepareSpawn(
+      'C:\\Program Files\\katago\\katago.bat',
+      ['--config', 'my config.cfg'],
+      {cwd: 'C:\\e'},
+      'win32'
+    )
+
+    t.equal(result.command, comspec)
+    t.same(result.args, [
+      '/d',
+      '/s',
+      '/c',
+      '"C:\\Program^ Files\\katago\\katago.bat ^"--config^" ^"my^ config.cfg^""'
+    ])
+  })
+
+  t.test('escapes embedded double quotes in arguments', async t => {
+    let result = prepareSpawn('C:\\e\\k.bat', ['say "hi"'], {}, 'win32')
+
+    t.same(result.args, [
+      '/d',
+      '/s',
+      '/c',
+      '"C:\\e\\k.bat ^"say^ \\^"hi\\^"^""'
+    ])
+  })
+
+  t.test('normalizes posix separators in the command path', async t => {
+    let result = prepareSpawn('C:/engines/k.bat', ['a'], {}, 'win32')
+
+    t.same(result.args, ['/d', '/s', '/c', '"C:\\engines\\k.bat ^"a^""'])
+  })
+
+  t.test(
+    'double-escapes metachars for node_modules/.bin cmd-shims',
+    async t => {
+      let result = prepareSpawn(
+        'C:\\proj\\node_modules\\.bin\\gtp2ogs.cmd',
+        ['--foo bar'],
+        {},
+        'win32'
+      )
+
+      t.same(result.args, [
+        '/d',
+        '/s',
+        '/c',
+        '"C:\\proj\\node_modules\\.bin\\gtp2ogs.cmd ^^^"--foo^^^ bar^^^""'
+      ])
+    }
+  )
+
+  t.test('does not mutate the caller-supplied args or options', async t => {
+    let args = ['--gtp', 'a b']
+    let options = {cwd: 'C:\\e'}
+
+    prepareSpawn('C:\\e\\k.bat', args, options, 'win32')
+
+    t.same(args, ['--gtp', 'a b'], 'args array untouched')
+    t.same(options, {cwd: 'C:\\e'}, 'options object untouched')
+    t.notOk(
+      'windowsVerbatimArguments' in options,
+      'no windowsVerbatimArguments leaked onto the original options'
+    )
+  })
+
+  t.test('does not double-wrap when the caller opted into a shell', async t => {
+    let options = {cwd: 'C:\\e', shell: true}
+    let result = prepareSpawn('C:\\e\\k.bat', ['--gtp'], options, 'win32')
+
+    t.equal(result.command, 'C:\\e\\k.bat', 'left to Node shell handling')
+    t.same(result.args, ['--gtp'])
+    t.equal(result.options, options)
+  })
+})


### PR DESCRIPTION
Fixes the Windows regression in SabakiHQ/Sabaki#1037. Since Node 18.20.2 / 20.12.2 / 21.7.2 (CVE-2024-27980), `child_process.spawn` on Windows throws `EINVAL` for a `.bat`/`.cmd` target unless it runs through a shell. Electron 43 bundles Node 24, so once Sabaki moved onto it, any engine configured as a `.bat` wrapper (pachi.bat, a python launcher, PhoenixGo's script, ...) stopped attaching, with no error. `Controller` spawns the path directly, so it hits this.

New pure helper `prepareSpawn(command, args, options, platform)`:

- Non-Windows, and Windows `.exe`/extensionless commands: returns the inputs unchanged (same refs), so the existing spawn path is untouched.
- Windows `.bat`/`.cmd` (case-insensitive): rewrites to `cmd.exe /d /s /c "<command> <args>"` with `windowsVerbatimArguments: true`, normalizing posix separators and escaping the command and each argument the way cmd.exe needs.

`Controller.start()` routes through it; `prepareSpawn` is exported too.

The cmd.exe escaping is ported inline from cross-spawn 7 to keep this package dependency-free (no runtime deps today). `tests/spawn.test.js` pins the exact output for paths and args with spaces and embedded quotes, and I checked it byte-for-byte against cross-spawn's own escaping across a fuzz run. If you'd rather just take the `cross-spawn` dep, I'm happy to swap it.

Existing suites pass via `node tests/<file>.test.js` (the tap CLI chokes on Node 24). I don't have a Windows box to launch a real `.bat`, so the tests pin the exact spawn call and I've asked the reporter to confirm on Windows before I tag a release.
